### PR TITLE
Add Version Requirement for D9 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Deprecated
+# Deprecated. Will be removed once the migration is complete
 
-# Rendered View Field - a Drupal 8 Module
+# Rendered View Field - a Drupal 8 Module. It's also compatible with D9
 
-A Drupal 8 Module that adds a new field type. So you can then reference rendered views in a node.
+A Drupal 8 Module(compatible with D9) that adds a new field type. So you can then reference rendered views in a node.
 
 Just install and clear caches.
 

--- a/rendered_view_field.info.yml
+++ b/rendered_view_field.info.yml
@@ -2,5 +2,6 @@ name: Rendered View Field
 type: module
 description: This Module creates a field in which you can select a view and this gets rendered in the frontend
 core: 8.x
+core_version_requirement : ^8 || ^9
 package: WONDROUS
 version: '0.0.1'


### PR DESCRIPTION
## Description
This module is not D9 Compatible. It's needed to be D9 compatible before D9 upgrade for many projects that are using it. We tested it with `upgrade_status` as well as manually to find deprecated code reference. But there was no deprecated code reference. So, just adding core version requirement will make it compatible for Drupal 9.

## Goal
- Add core version requirement 
- Create a new tag release

## Acceptance 
-  Module is D9 Compatible 
- Module is functional 